### PR TITLE
Add tools button and placeholder pages

### DIFF
--- a/app.php
+++ b/app.php
@@ -36,6 +36,18 @@ $router->addRoute('GET', '/update-code', function () {
     )];
 }, $app->appRoot . '/templates/shell_command_raw_content.html.php');
 
+$router->addRoute('GET', '/tools', function () {
+    return [];
+}, $app->appRoot . '/templates/tools.html.php');
+
+$router->addRoute('GET', '/tools/example1', function () {
+    return [];
+}, $app->appRoot . '/templates/example1.html.php');
+
+$router->addRoute('GET', '/tools/example2', function () {
+    return [];
+}, $app->appRoot . '/templates/example2.html.php');
+
 $router->addRoute('GET', '/file-index', function () {
     // Use the configurable catalog path from settings
     $fileIndexManager = new FileIndexManager();

--- a/templates/example1.html.php
+++ b/templates/example1.html.php
@@ -1,0 +1,5 @@
+<div class="row">
+    <div class="col-sm">
+        <h2>example1</h2>
+    </div>
+</div>

--- a/templates/example2.html.php
+++ b/templates/example2.html.php
@@ -1,0 +1,5 @@
+<div class="row">
+    <div class="col-sm">
+        <h2>example2</h2>
+    </div>
+</div>

--- a/templates/tools.html.php
+++ b/templates/tools.html.php
@@ -1,0 +1,6 @@
+<div class="row">
+    <div class="col-sm">
+        <a class="btn btn-secondary" href="/tools/example1">example1</a>
+        <a class="btn btn-secondary" href="/tools/example2">example2</a>
+    </div>
+</div>

--- a/templates/top_main_menu.html.php
+++ b/templates/top_main_menu.html.php
@@ -17,5 +17,6 @@
         <a class="btn btn-primary" href="/">index</a>
         <a class="btn btn-primary" href="/top">top</a>
         <a class="btn btn-primary" href="/file-index">file index</a>
+        <a class="btn btn-primary" href="/tools">tools</a>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add a Tools button to the main menu
- create a simple Tools page linking to two example pages
- provide placeholder templates for example pages
- register new routes for the tools pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ab1a53e688327806b4d7a1434a83f