### PR TITLE
Persist video playback progress on backend

### DIFF
--- a/app/Controller/FileIndexController.php
+++ b/app/Controller/FileIndexController.php
@@ -136,6 +136,49 @@ class FileIndexController
         return $meta;
     }
 
+    private static function getVideoProgressStoragePath(): string
+    {
+        $baseDir = self::getUploadBaseDir();
+        if (!is_dir($baseDir)) {
+            @mkdir($baseDir, 0775, true);
+        }
+        return rtrim($baseDir, '/') . '/video_progress.json';
+    }
+
+    private static function loadVideoProgressMap(): array
+    {
+        $storagePath = self::getVideoProgressStoragePath();
+        if (!is_file($storagePath)) {
+            return [];
+        }
+
+        $json = @file_get_contents($storagePath);
+        if ($json === false || trim($json) === '') {
+            return [];
+        }
+
+        $map = json_decode($json, true);
+        if (!is_array($map)) {
+            return [];
+        }
+
+        return $map;
+    }
+
+    private static function saveVideoProgressMap(array $map): void
+    {
+        $storagePath = self::getVideoProgressStoragePath();
+        $encoded = json_encode($map, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($encoded === false) {
+            throw new \RuntimeException('Failed to encode video progress map');
+        }
+
+        $ok = @file_put_contents($storagePath, $encoded, LOCK_EX);
+        if ($ok === false) {
+            throw new \RuntimeException('Failed to write video progress map');
+        }
+    }
+
     private static function listReceivedChunks(string $uploadDir, int $totalChunks): array
     {
         $received = [];
@@ -182,6 +225,8 @@ class FileIndexController
         $router->addRoute('POST', '/file-index/unpin', [$this, 'unpin']);
         $router->addRoute('GET', '/file-index/download', [$this, 'downloadDirectory']);
         $router->addRoute('GET', '/file-index/stream', [$this, 'streamVideo']);
+        $router->addRoute('GET', '/file-index/video-progress', [$this, 'getVideoProgress']);
+        $router->addRoute('POST', '/file-index/video-progress', [$this, 'saveVideoProgress']);
         $router->addRoute('GET', '/file-index/download/file', [$this, 'downloadFile']);
         $router->addRoute('GET', '/file-index/nfo', [$this, 'getNfo']);
         $router->addRoute('POST', '/file-index/nfo', [$this, 'saveNfo']);
@@ -1139,6 +1184,61 @@ class FileIndexController
         }
 
         exit;
+    }
+
+    public function getVideoProgress(): string
+    {
+        $path = (string)($_GET['path'] ?? '');
+        if (trim($path) === '') {
+            self::jsonResponse(['ok' => false, 'error' => 'Path is required'], 400);
+        }
+
+        try {
+            $normalizedPath = PathGuard::segmentsToRelativePath(PathGuard::toSegments($path));
+        } catch (\InvalidArgumentException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 400);
+        }
+
+        $progressMap = self::loadVideoProgressMap();
+        $time = (float)($progressMap[$normalizedPath] ?? 0);
+        self::jsonResponse(['ok' => true, 'time' => max(0, $time)]);
+    }
+
+    public function saveVideoProgress(): string
+    {
+        $payload = $_POST;
+        if (empty($payload)) {
+            $raw = file_get_contents('php://input');
+            $decoded = json_decode((string)$raw, true);
+            if (is_array($decoded)) {
+                $payload = $decoded;
+            }
+        }
+
+        $path = trim((string)($payload['path'] ?? ''));
+        $time = (float)($payload['time'] ?? 0);
+
+        if ($path === '') {
+            self::jsonResponse(['ok' => false, 'error' => 'Path is required'], 400);
+        }
+
+        try {
+            $normalizedPath = PathGuard::segmentsToRelativePath(PathGuard::toSegments($path));
+        } catch (\InvalidArgumentException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 400);
+        }
+
+        $safeTime = max(0, $time);
+
+        try {
+            $progressMap = self::loadVideoProgressMap();
+            $progressMap[$normalizedPath] = $safeTime;
+            self::saveVideoProgressMap($progressMap);
+        } catch (\RuntimeException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 500);
+        }
+
+        self::jsonResponse(['ok' => true, 'time' => $safeTime]);
     }
 
     public function downloadFile(): string

--- a/app/Controller/FileIndexController.php
+++ b/app/Controller/FileIndexController.php
@@ -226,6 +226,7 @@ class FileIndexController
         $router->addRoute('GET', '/file-index/download', [$this, 'downloadDirectory']);
         $router->addRoute('GET', '/file-index/stream', [$this, 'streamVideo']);
         $router->addRoute('GET', '/file-index/video-progress', [$this, 'getVideoProgress']);
+        $router->addRoute('GET', '/file-index/video-progress/list', [$this, 'getVideoProgressList']);
         $router->addRoute('POST', '/file-index/video-progress', [$this, 'saveVideoProgress']);
         $router->addRoute('GET', '/file-index/download/file', [$this, 'downloadFile']);
         $router->addRoute('GET', '/file-index/nfo', [$this, 'getNfo']);
@@ -1200,8 +1201,50 @@ class FileIndexController
         }
 
         $progressMap = self::loadVideoProgressMap();
-        $time = (float)($progressMap[$normalizedPath] ?? 0);
+        $rawProgress = $progressMap[$normalizedPath] ?? 0;
+        $time = is_array($rawProgress) ? (float)($rawProgress['time'] ?? 0) : (float)$rawProgress;
         self::jsonResponse(['ok' => true, 'time' => max(0, $time)]);
+    }
+
+    public function getVideoProgressList(): string
+    {
+        $paths = $_GET['paths'] ?? [];
+        if (!is_array($paths)) {
+            self::jsonResponse(['ok' => false, 'error' => 'paths must be an array'], 400);
+        }
+
+        $progressMap = self::loadVideoProgressMap();
+        $result = [];
+
+        foreach ($paths as $path) {
+            $path = trim((string)$path);
+            if ($path === '') {
+                continue;
+            }
+
+            try {
+                $normalizedPath = PathGuard::segmentsToRelativePath(PathGuard::toSegments($path));
+            } catch (\InvalidArgumentException) {
+                continue;
+            }
+
+            $rawProgress = $progressMap[$normalizedPath] ?? 0;
+            $time = is_array($rawProgress) ? (float)($rawProgress['time'] ?? 0) : (float)$rawProgress;
+            $duration = is_array($rawProgress) ? (float)($rawProgress['duration'] ?? 0) : 0.0;
+            $percent = is_array($rawProgress) ? (int)($rawProgress['percent'] ?? 0) : 0;
+
+            if ($percent <= 0 && $duration > 0) {
+                $percent = (int)round((max(0, $time) / $duration) * 100);
+            }
+
+            $result[$normalizedPath] = [
+                'time' => max(0, $time),
+                'duration' => max(0, $duration),
+                'percent' => min(100, max(0, $percent)),
+            ];
+        }
+
+        self::jsonResponse(['ok' => true, 'progress' => $result]);
     }
 
     public function saveVideoProgress(): string
@@ -1217,6 +1260,7 @@ class FileIndexController
 
         $path = trim((string)($payload['path'] ?? ''));
         $time = (float)($payload['time'] ?? 0);
+        $duration = (float)($payload['duration'] ?? 0);
 
         if ($path === '') {
             self::jsonResponse(['ok' => false, 'error' => 'Path is required'], 400);
@@ -1229,16 +1273,31 @@ class FileIndexController
         }
 
         $safeTime = max(0, $time);
+        $safeDuration = max(0, $duration);
+        $percent = 0;
+        if ($safeDuration > 0) {
+            $percent = (int)round(($safeTime / $safeDuration) * 100);
+        }
+        $safePercent = min(100, max(0, $percent));
 
         try {
             $progressMap = self::loadVideoProgressMap();
-            $progressMap[$normalizedPath] = $safeTime;
+            $progressMap[$normalizedPath] = [
+                'time' => $safeTime,
+                'duration' => $safeDuration,
+                'percent' => $safePercent,
+            ];
             self::saveVideoProgressMap($progressMap);
         } catch (\RuntimeException $e) {
             self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 500);
         }
 
-        self::jsonResponse(['ok' => true, 'time' => $safeTime]);
+        self::jsonResponse([
+            'ok' => true,
+            'time' => $safeTime,
+            'duration' => $safeDuration,
+            'percent' => $safePercent,
+        ]);
     }
 
     public function downloadFile(): string

--- a/templates/file_index.html.php
+++ b/templates/file_index.html.php
@@ -526,29 +526,44 @@ document.addEventListener('DOMContentLoaded', function() {
         'mov': 'video/quicktime', 'mkv': 'video/x-matroska', 'avi': 'video/x-msvideo'
     };
 
-    // --- LocalStorage helpers ---
-    function saveVideoTime(path, time) {
+    // --- Backend video progress helpers ---
+    async function saveVideoTime(path, time) {
         if (!path) return;
         // Prevent overwriting valid saved time with 0 if video hasn't started/restored properly yet
         if (!isVideoReadyForSave && time < 1) {
             return;
         }
+
         try {
-            const videoProgress = JSON.parse(localStorage.getItem('videoProgress') || '{}');
-            videoProgress[path] = time;
-            localStorage.setItem('videoProgress', JSON.stringify(videoProgress));
+            await fetch('/file-index/video-progress', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    path: path,
+                    time: Number(time) || 0,
+                }),
+            });
         } catch (e) {
-            console.error("Failed to save video time to localStorage", e);
+            console.error("Failed to save video time to backend", e);
         }
     }
 
-    function getSavedVideoTime(path) {
+    async function getSavedVideoTime(path) {
         if (!path) return 0;
+
         try {
-            const videoProgress = JSON.parse(localStorage.getItem('videoProgress') || '{}');
-            return parseFloat(videoProgress[path] || 0);
+            const url = '/file-index/video-progress?path=' + encodeURIComponent(path);
+            const response = await fetch(url, { method: 'GET' });
+            if (!response.ok) return 0;
+
+            const payload = await response.json();
+            if (!payload || !payload.ok) return 0;
+
+            return parseFloat(payload.time || 0);
         } catch (e) {
-            console.error("Failed to get video time from localStorage", e);
+            console.error("Failed to get video time from backend", e);
             return 0;
         }
     }
@@ -725,8 +740,8 @@ document.addEventListener('DOMContentLoaded', function() {
             setupHoldToSpeed();
         });
 
-        player.on('loadedmetadata', function() {
-            const savedTime = getSavedVideoTime(currentVideoPath);
+        player.on('loadedmetadata', async function() {
+            const savedTime = await getSavedVideoTime(currentVideoPath);
             if (savedTime > 0) {
                 player.currentTime = savedTime;
             }
@@ -736,7 +751,7 @@ document.addEventListener('DOMContentLoaded', function() {
         player.on('timeupdate', function() {
             if (isVideoReadyForSave && !timeUpdateTimeout) {
                 timeUpdateTimeout = setTimeout(() => {
-                    saveVideoTime(currentVideoPath, player.currentTime);
+                    void saveVideoTime(currentVideoPath, player.currentTime);
                     timeUpdateTimeout = null;
                 }, SAVE_INTERVAL);
             }
@@ -754,7 +769,7 @@ document.addEventListener('DOMContentLoaded', function() {
             clearTimeout(timeUpdateTimeout);
             timeUpdateTimeout = null;
             if (isVideoReadyForSave) {
-                saveVideoTime(currentVideoPath, player.currentTime);
+                void saveVideoTime(currentVideoPath, player.currentTime);
             }
             player.pause();
             isVideoReadyForSave = false;

--- a/templates/file_index.html.php
+++ b/templates/file_index.html.php
@@ -195,6 +195,15 @@
                                             <?= htmlspecialchars($file['name']) ?>
                                         <?php endif; ?>
                                     </span>
+                                    <?php if (!$file['isDir']): ?>
+                                        <?php
+                                        $nameExt = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+                                        $isVideoFileForProgress = in_array($nameExt, ['mp4', 'webm', 'ogg', 'mov', 'mkv', 'avi', 'm4v']);
+                                        ?>
+                                        <?php if ($isVideoFileForProgress): ?>
+                                            <div class="small text-muted file-video-progress d-none" data-video-progress-path="<?= htmlspecialchars($file['path']) ?>">▶ Progress: <span class="file-video-progress-percent">0%</span></div>
+                                        <?php endif; ?>
+                                    <?php endif; ?>
                                 </td>
                                 <td>
                                     <?php if (!$file['isDir'] && $file['size'] > 0): ?>
@@ -527,7 +536,7 @@ document.addEventListener('DOMContentLoaded', function() {
     };
 
     // --- Backend video progress helpers ---
-    async function saveVideoTime(path, time) {
+    async function saveVideoTime(path, time, duration) {
         if (!path) return;
         // Prevent overwriting valid saved time with 0 if video hasn't started/restored properly yet
         if (!isVideoReadyForSave && time < 1) {
@@ -543,6 +552,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 body: JSON.stringify({
                     path: path,
                     time: Number(time) || 0,
+                    duration: Number(duration) || 0,
                 }),
             });
         } catch (e) {
@@ -565,6 +575,50 @@ document.addEventListener('DOMContentLoaded', function() {
         } catch (e) {
             console.error("Failed to get video time from backend", e);
             return 0;
+        }
+    }
+
+
+    async function loadVideoProgressForFileList() {
+        const progressRows = Array.from(document.querySelectorAll('[data-video-progress-path]'));
+        if (!progressRows.length) return;
+
+        const paths = progressRows
+            .map((row) => row.dataset.videoProgressPath || '')
+            .filter((value) => value);
+
+        if (!paths.length) return;
+
+        try {
+            const params = new URLSearchParams();
+            for (const path of paths) {
+                params.append('paths[]', path);
+            }
+
+            const response = await fetch('/file-index/video-progress/list?' + params.toString(), {
+                method: 'GET',
+            });
+            if (!response.ok) return;
+
+            const payload = await response.json();
+            if (!payload || !payload.ok || !payload.progress) return;
+
+            for (const row of progressRows) {
+                const path = row.dataset.videoProgressPath || '';
+                const progress = payload.progress[path];
+                if (!progress) continue;
+
+                const percent = Math.max(0, Math.min(100, Number(progress.percent) || 0));
+                if (percent <= 0) continue;
+
+                const percentEl = row.querySelector('.file-video-progress-percent');
+                if (percentEl) {
+                    percentEl.textContent = percent.toFixed(0) + '%';
+                }
+                row.classList.remove('d-none');
+            }
+        } catch (e) {
+            console.error('Failed to load file list video progress', e);
         }
     }
 
@@ -751,7 +805,7 @@ document.addEventListener('DOMContentLoaded', function() {
         player.on('timeupdate', function() {
             if (isVideoReadyForSave && !timeUpdateTimeout) {
                 timeUpdateTimeout = setTimeout(() => {
-                    void saveVideoTime(currentVideoPath, player.currentTime);
+                    void saveVideoTime(currentVideoPath, player.currentTime, player.duration);
                     timeUpdateTimeout = null;
                 }, SAVE_INTERVAL);
             }
@@ -760,6 +814,7 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Initialize on load
     initPlyr();
+    void loadVideoProgressForFileList();
         
     // Stop video and save final time when modal closes
     videoModalElement.addEventListener('hidden.bs.modal', function() {
@@ -769,7 +824,7 @@ document.addEventListener('DOMContentLoaded', function() {
             clearTimeout(timeUpdateTimeout);
             timeUpdateTimeout = null;
             if (isVideoReadyForSave) {
-                void saveVideoTime(currentVideoPath, player.currentTime);
+                void saveVideoTime(currentVideoPath, player.currentTime, player.duration);
             }
             player.pause();
             isVideoReadyForSave = false;


### PR DESCRIPTION
### Motivation
- Store video playback progress on the server instead of `localStorage` so progress is available across clients and survives browser storage limits. 

### Description
- Added backend storage utilities and a JSON store under the existing upload/temp base directory via `getVideoProgressStoragePath()`, `loadVideoProgressMap()` and `saveVideoProgressMap()` in `app/Controller/FileIndexController.php`.
- Registered new routes `GET /file-index/video-progress` and `POST /file-index/video-progress` and implemented `getVideoProgress()` and `saveVideoProgress()` which normalize paths with `PathGuard` and return JSON responses.
- Updated the frontend in `templates/file_index.html.php` to replace `localStorage` helpers with async `fetch` calls to the new backend endpoints and changed player handlers to `await` restore and asynchronously persist periodic and final saves while preserving throttling behavior.
- Paths are normalized before read/write and progress times are clamped to `>= 0`; the backend persistence file is `video_progress.json` located inside the upload/temp base directory returned by `getUploadBaseDir()`.

### Testing
- Ran PHP syntax checks: `php -l app/Controller/FileIndexController.php` (passed) and `php -l templates/file_index.html.php` (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ed43f6c48330936c55916b776d57)