### PR TITLE
Add URL download (aria2c with wget fallback) to File Index

### DIFF
--- a/app/Controller/FileIndexController.php
+++ b/app/Controller/FileIndexController.php
@@ -74,6 +74,50 @@ class FileIndexController
         exit;
     }
 
+    private static function commandExists(string $command): bool
+    {
+        $result = @shell_exec('command -v ' . escapeshellarg($command) . ' 2>/dev/null');
+        return is_string($result) && trim($result) !== '';
+    }
+
+    private static function downloadByUrlToDirectory(string $url, string $targetDir): array
+    {
+        $escapedDir = escapeshellarg($targetDir);
+        $escapedUrl = escapeshellarg($url);
+
+        $commands = [];
+        if (self::commandExists('aria2c')) {
+            $commands[] = [
+                'tool' => 'aria2c',
+                'cmd' => 'aria2c --allow-overwrite=false --auto-file-renaming=false --dir=' . $escapedDir . ' -- ' . $escapedUrl . ' 2>&1',
+            ];
+        }
+        if (self::commandExists('wget')) {
+            $commands[] = [
+                'tool' => 'wget',
+                'cmd' => 'wget -P ' . $escapedDir . ' -- ' . $escapedUrl . ' 2>&1',
+            ];
+        }
+
+        if (count($commands) === 0) {
+            return ['ok' => false, 'error' => 'Neither aria2c nor wget is available on the server'];
+        }
+
+        $errors = [];
+        foreach ($commands as $item) {
+            $output = [];
+            $exitCode = 1;
+            @exec($item['cmd'], $output, $exitCode);
+            if ($exitCode === 0) {
+                return ['ok' => true, 'tool' => $item['tool']];
+            }
+            $tail = trim((string)implode("\n", array_slice($output, -5)));
+            $errors[] = $item['tool'] . ($tail !== '' ? (': ' . $tail) : ': failed with exit code ' . $exitCode);
+        }
+
+        return ['ok' => false, 'error' => implode(' | ', $errors)];
+    }
+
     private static function getUploadBaseDir(): string
     {
         $candidates = [];
@@ -217,6 +261,7 @@ class FileIndexController
         $router->addRoute('POST', '/file-index/dir/delete', [$this, 'deleteDirectory']);
         $router->addRoute('POST', '/file-index/dir/rename', [$this, 'renameDirectory']);
         $router->addRoute('POST', '/file-index/upload', [$this, 'uploadFile']);
+        $router->addRoute('POST', '/file-index/download-url', [$this, 'downloadByUrl']);
         $router->addRoute('POST', '/file-index/upload/init', [$this, 'uploadInit']);
         $router->addRoute('POST', '/file-index/upload/status', [$this, 'uploadStatus']);
         $router->addRoute('POST', '/file-index/upload/chunk', [$this, 'uploadChunk']);
@@ -591,6 +636,53 @@ class FileIndexController
             $lastError = error_get_last();
             $reason = $lastError['message'] ?? 'unknown error';
             self::redirectWithError($redirectUrl, 'Failed to save uploaded file: ' . $reason);
+        }
+
+        header('Location: ' . $redirectUrl);
+        exit;
+    }
+
+    public function downloadByUrl(): string
+    {
+        $fileIndexManager = new FileIndexManager();
+        $catalogPath = $fileIndexManager->getCatalogPath();
+
+        $returnPath = (string)($_POST['returnPath'] ?? '');
+        $targetPath = (string)($_POST['targetPath'] ?? '');
+        $url = trim((string)($_POST['url'] ?? ''));
+
+        $redirectUrl = self::buildRedirectUrl($returnPath);
+
+        if ($url === '') {
+            self::redirectWithError($redirectUrl, 'Download URL is required');
+        }
+
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            self::redirectWithError($redirectUrl, 'Invalid download URL');
+        }
+
+        $scheme = strtolower((string)parse_url($url, PHP_URL_SCHEME));
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            self::redirectWithError($redirectUrl, 'Only HTTP/HTTPS URLs are supported');
+        }
+
+        try {
+            $targetSegments = PathGuard::toSegmentsAllowEmpty($targetPath);
+        } catch (\InvalidArgumentException $e) {
+            self::redirectWithError($redirectUrl, $e->getMessage());
+        }
+
+        $targetDir = PathGuard::joinCatalog($catalogPath, $targetSegments);
+        if (!is_dir($targetDir)) {
+            self::redirectWithError($redirectUrl, 'Target directory not found');
+        }
+        if (!@is_writable($targetDir)) {
+            self::redirectWithError($redirectUrl, 'Target directory is not writable');
+        }
+
+        $result = self::downloadByUrlToDirectory($url, $targetDir);
+        if (!($result['ok'] ?? false)) {
+            self::redirectWithError($redirectUrl, 'Download failed. ' . ($result['error'] ?? 'Unknown error'));
         }
 
         header('Location: ' . $redirectUrl);

--- a/templates/file_index.html.php
+++ b/templates/file_index.html.php
@@ -96,6 +96,22 @@
                             </div>
                         </form>
                     </div>
+
+                    <div class="col-12">
+                        <form action="/file-index/download-url" method="POST" class="row g-2">
+                            <div class="col-12">
+                                <label class="form-label mb-1">Download from URL (aria2c, fallback wget)</label>
+                            </div>
+                            <div class="col-12 col-lg-10">
+                                <input type="url" class="form-control" name="url" placeholder="https://example.com/file.zip" autocomplete="off" required>
+                                <input type="hidden" name="targetPath" value="<?= htmlspecialchars($currentPath ?? '') ?>">
+                                <input type="hidden" name="returnPath" value="<?= htmlspecialchars($currentPath ?? '') ?>">
+                            </div>
+                            <div class="col-12 col-lg-2">
+                                <button type="submit" class="btn btn-outline-success w-100">⬇️ Download</button>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Motivation

- Позволить загружать файл в текущую папку каталога напрямую по ссылке из интерфейса, используя `aria2c` как первичный загрузчик с фолбеком на `wget` при отсутствии или ошибке.

### Description

- Добавлены утилиты в `FileIndexController`: `commandExists()` для проверки наличия бинарников и `downloadByUrlToDirectory()` для последовательного запуска `aria2c` и затем `wget` с возвратом диагностики по ошибке.
- Реализован экшен `downloadByUrl()` с валидацией входного URL (обязательный, `http`/`https`), безопасным разрешением целевой папки через `PathGuard` и проверкой прав на запись, и добавлен маршрут `POST /file-index/download-url`.
- В шаблон `templates/file_index.html.php` добавлена форма "Download from URL (aria2c, fallback wget)" с полями `url`, `targetPath` и `returnPath`, чтобы загрузки попадали в текущую папку и пользователь возвращался на ту же страницу.
- Все вызовы внешних команд выполняются безопасно через экранирование аргументов и собирается короткий хвост вывода для диагностики при неудаче.

### Testing

- Выполнен синтаксический анализ файлов командой `php -l` для `app/Controller/FileIndexController.php` и `templates/file_index.html.php`, оба файла прошли проверку успешно.
- Локально поднят встроенный сервер `php -S 0.0.0.0:8000 app.php` и проверен доступ к странице `/file-index`, запуск прошёл успешно.
- Выполнена визуальная проверка интерфейса через Playwright (скриншот страницы `/file-index`) и форма загрузки по URL отображается корректно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c4661530c833091dcfe79a51bd80f)