### PR TITLE
Add Docker SSH execution with shared master connection and cache video progress restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor
 /.idea/*
 .DS_Store
+.env.ssh
+.docker-ssh/

--- a/DOCKER_SSH_README.md
+++ b/DOCKER_SSH_README.md
@@ -1,0 +1,42 @@
+# Docker + single SSH connection
+
+This setup runs the app in Docker and executes shell commands over one shared SSH connection.
+
+## 1) Prepare key and env
+
+```bash
+./scripts/setup-docker-ssh-key.sh
+```
+
+What the script does:
+- generates a dedicated Ed25519 key in `.docker-ssh/` (if missing)
+- writes `.env.ssh` with `SSH_REMOTE_HOST`, `SSH_REMOTE_PORT`, `SSH_REMOTE_USER`, `SSH_PRIVATE_KEY_B64`
+- appends the public key to remote `~/.ssh/authorized_keys` only if it is not already present (does not overwrite existing keys)
+
+## 2) Start
+
+```bash
+docker compose up --build
+```
+
+App is available at `http://localhost:8080`.
+
+## How single SSH session works
+
+Container entrypoint (`init-ssh-and-run.sh`) creates SSH config with:
+- `ControlMaster auto`
+- `ControlPersist 10m`
+- `ControlPath /tmp/ssh/cm-%r@%h:%p`
+
+Then it runs:
+
+```bash
+ssh -F /tmp/ssh/config -MNf remote-target
+```
+
+This opens one master connection. Subsequent command executions use `run-over-ssh.sh`, reusing the same control socket.
+
+## Notes
+
+- Keep `.env.ssh` and `.docker-ssh/` private.
+- If remote host changes, rerun `./scripts/setup-docker-ssh-key.sh`.

--- a/DOCKER_SSH_README.md
+++ b/DOCKER_SSH_README.md
@@ -1,6 +1,6 @@
-# Docker + single SSH connection
+# Docker + Nginx + single SSH connection
 
-This setup runs the app in Docker and executes shell commands over one shared SSH connection.
+This setup runs the app in Docker behind Nginx (port 80) and executes shell commands over one shared SSH connection.
 
 ## 1) Prepare key and env
 
@@ -19,11 +19,19 @@ What the script does:
 docker compose up --build
 ```
 
-App is available at `http://localhost:8080`.
+App is available at `http://localhost` (port `80` by default).
+
+## Runtime architecture
+
+- `nginx` container serves HTTP on port `80`
+- `app` container runs `php-fpm`
+- Nginx forwards PHP requests to `app:9000`
+
+The app is **not** started with `php -S`.
 
 ## How single SSH session works
 
-Container entrypoint (`init-ssh-and-run.sh`) creates SSH config with:
+Container init (`init-ssh-and-run.sh`) creates SSH config with:
 - `ControlMaster auto`
 - `ControlPersist 10m`
 - `ControlPath /tmp/ssh/cm-%r@%h:%p`

--- a/app/ShellCommandExecutor.php
+++ b/app/ShellCommandExecutor.php
@@ -6,7 +6,8 @@ class ShellCommandExecutor
 {
     public static function execute(string $command): string
     {
-        $result = shell_exec($command);
+        $effectiveCommand = self::buildEffectiveCommand($command);
+        $result = shell_exec($effectiveCommand);
 
         if ($result === null) {
             throw new \RuntimeException('Command execution failed');
@@ -25,5 +26,19 @@ class ShellCommandExecutor
             ];
         }
         return explode("\n", $result);
+    }
+
+    private static function buildEffectiveCommand(string $command): string
+    {
+        if (getenv('SHELL_OVER_SSH') !== '1') {
+            return $command;
+        }
+
+        $wrapper = '/usr/local/bin/run-over-ssh.sh';
+        if (!is_executable($wrapper)) {
+            return $command;
+        }
+
+        return escapeshellcmd($wrapper) . ' ' . escapeshellarg($command);
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
 services:
-  rpi-mainpage:
+  app:
     build:
       context: .
       dockerfile: docker/php/Dockerfile
-    container_name: rpi-mainpage
-    ports:
-      - "8080:80"
+    container_name: rpi-mainpage-app
     volumes:
       - ./:/app
     env_file:
@@ -18,4 +16,15 @@ services:
       SSH_CONTROL_PATH: /tmp/ssh/cm-%r@%h:%p
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    command: ["/usr/local/bin/init-ssh-and-run.sh", "php", "-S", "0.0.0.0:80", "-t", "/app"]
+    command: ["/usr/local/bin/init-ssh-and-run.sh", "php-fpm", "-F"]
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: rpi-mainpage-nginx
+    depends_on:
+      - app
+    ports:
+      - "80:80"
+    volumes:
+      - ./:/app:ro
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  rpi-mainpage:
+    build:
+      context: .
+      dockerfile: docker/php/Dockerfile
+    container_name: rpi-mainpage
+    ports:
+      - "8080:80"
+    volumes:
+      - ./:/app
+    env_file:
+      - .env.ssh
+    environment:
+      SHELL_OVER_SSH: "1"
+      SSH_REMOTE_HOST: ${SSH_REMOTE_HOST:-host.docker.internal}
+      SSH_REMOTE_PORT: ${SSH_REMOTE_PORT:-22}
+      SSH_REMOTE_USER: ${SSH_REMOTE_USER:-ubuntu}
+      SSH_CONTROL_PATH: /tmp/ssh/cm-%r@%h:%p
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: ["/usr/local/bin/init-ssh-and-run.sh", "php", "-S", "0.0.0.0:80", "-t", "/app"]

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /app;
+    index index.php index.html;
+
+    client_max_body_size 512m;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $document_root;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli
+FROM php:8.2-fpm
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends openssh-client git unzip \

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:8.2-cli
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssh-client git unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY docker/php/init-ssh-and-run.sh /usr/local/bin/init-ssh-and-run.sh
+COPY docker/php/run-over-ssh.sh /usr/local/bin/run-over-ssh.sh
+RUN chmod +x /usr/local/bin/init-ssh-and-run.sh /usr/local/bin/run-over-ssh.sh

--- a/docker/php/init-ssh-and-run.sh
+++ b/docker/php/init-ssh-and-run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+set -eu
+
+SSH_DIR="/tmp/ssh"
+KEY_PATH="$SSH_DIR/id_ed25519"
+CONFIG_PATH="$SSH_DIR/config"
+
+mkdir -p "$SSH_DIR"
+chmod 700 "$SSH_DIR"
+
+if [ -n "${SSH_PRIVATE_KEY_B64:-}" ]; then
+  printf '%s' "$SSH_PRIVATE_KEY_B64" | base64 -d > "$KEY_PATH"
+  chmod 600 "$KEY_PATH"
+fi
+
+if [ ! -s "$KEY_PATH" ]; then
+  echo "SSH key is missing. Run scripts/setup-docker-ssh-key.sh first." >&2
+  exit 1
+fi
+
+: "${SSH_REMOTE_HOST:?SSH_REMOTE_HOST is required}"
+: "${SSH_REMOTE_PORT:=22}"
+: "${SSH_REMOTE_USER:?SSH_REMOTE_USER is required}"
+: "${SSH_CONTROL_PATH:=/tmp/ssh/cm-%r@%h:%p}"
+
+cat > "$CONFIG_PATH" <<EOF
+Host remote-target
+  HostName ${SSH_REMOTE_HOST}
+  Port ${SSH_REMOTE_PORT}
+  User ${SSH_REMOTE_USER}
+  IdentityFile ${KEY_PATH}
+  IdentitiesOnly yes
+  StrictHostKeyChecking accept-new
+  UserKnownHostsFile ${SSH_DIR}/known_hosts
+  ControlMaster auto
+  ControlPersist 10m
+  ControlPath ${SSH_CONTROL_PATH}
+EOF
+chmod 600 "$CONFIG_PATH"
+
+# Warm up the shared SSH connection once.
+ssh -F "$CONFIG_PATH" -MNf remote-target || true
+
+exec "$@"

--- a/docker/php/run-over-ssh.sh
+++ b/docker/php/run-over-ssh.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -eu
+
+REMOTE_COMMAND="${1:-}"
+if [ -z "$REMOTE_COMMAND" ]; then
+  exit 0
+fi
+
+CONFIG_PATH="/tmp/ssh/config"
+if [ ! -f "$CONFIG_PATH" ]; then
+  echo "SSH config not found at $CONFIG_PATH" >&2
+  exit 1
+fi
+
+ssh -F "$CONFIG_PATH" remote-target -- bash -lc "$REMOTE_COMMAND"

--- a/scripts/setup-docker-ssh-key.sh
+++ b/scripts/setup-docker-ssh-key.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env.ssh"
+KEY_DIR="${ROOT_DIR}/.docker-ssh"
+KEY_PATH="${KEY_DIR}/id_ed25519"
+PUB_PATH="${KEY_PATH}.pub"
+
+mkdir -p "${KEY_DIR}"
+chmod 700 "${KEY_DIR}"
+
+if [ ! -f "${KEY_PATH}" ]; then
+  ssh-keygen -t ed25519 -N "" -f "${KEY_PATH}" -C "docker-rpi-mainpage" >/dev/null
+fi
+
+chmod 600 "${KEY_PATH}"
+chmod 644 "${PUB_PATH}"
+
+DEFAULT_HOST="${SSH_REMOTE_HOST:-}"
+DEFAULT_PORT="${SSH_REMOTE_PORT:-22}"
+DEFAULT_USER="${SSH_REMOTE_USER:-ubuntu}"
+
+read -r -p "Remote host [${DEFAULT_HOST:-127.0.0.1}]: " INPUT_HOST || true
+read -r -p "Remote port [${DEFAULT_PORT}]: " INPUT_PORT || true
+read -r -p "Remote user [${DEFAULT_USER}]: " INPUT_USER || true
+
+REMOTE_HOST="${INPUT_HOST:-${DEFAULT_HOST:-127.0.0.1}}"
+REMOTE_PORT="${INPUT_PORT:-${DEFAULT_PORT}}"
+REMOTE_USER="${INPUT_USER:-${DEFAULT_USER}}"
+
+if [ -z "${REMOTE_HOST}" ] || [ -z "${REMOTE_USER}" ]; then
+  echo "Remote host and user are required" >&2
+  exit 1
+fi
+
+KEY_B64="$(base64 -w0 "${KEY_PATH}")"
+cat > "${ENV_FILE}" <<EOF
+SSH_REMOTE_HOST=${REMOTE_HOST}
+SSH_REMOTE_PORT=${REMOTE_PORT}
+SSH_REMOTE_USER=${REMOTE_USER}
+SSH_PRIVATE_KEY_B64=${KEY_B64}
+EOF
+
+PUB_KEY="$(cat "${PUB_PATH}")"
+SSH_OPTS=( -p "${REMOTE_PORT}" -o StrictHostKeyChecking=accept-new )
+
+ssh "${SSH_OPTS[@]}" "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p ~/.ssh && chmod 700 ~/.ssh && touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && grep -qxF '${PUB_KEY}' ~/.ssh/authorized_keys || echo '${PUB_KEY}' >> ~/.ssh/authorized_keys"
+
+echo "Prepared ${ENV_FILE} and ensured public key is present on ${REMOTE_USER}@${REMOTE_HOST}"

--- a/templates/file_index.html.php
+++ b/templates/file_index.html.php
@@ -507,6 +507,8 @@ document.addEventListener('DOMContentLoaded', function() {
     let currentVideoPath = null;
     let timeUpdateTimeout = null;
     let isVideoReadyForSave = false; // Flag to prevent saving 0.00s on initial load
+    let currentVideoProgressRequest = null;
+    const prefetchedVideoProgress = new Map();
     let holdSpeedRestoreValue = 1;
     let holdSpeedTimeout = null;
     let holdToSpeedActive = false;
@@ -563,6 +565,10 @@ document.addEventListener('DOMContentLoaded', function() {
     async function getSavedVideoTime(path) {
         if (!path) return 0;
 
+        if (prefetchedVideoProgress.has(path)) {
+            return prefetchedVideoProgress.get(path) || 0;
+        }
+
         try {
             const url = '/file-index/video-progress?path=' + encodeURIComponent(path);
             const response = await fetch(url, { method: 'GET' });
@@ -571,11 +577,19 @@ document.addEventListener('DOMContentLoaded', function() {
             const payload = await response.json();
             if (!payload || !payload.ok) return 0;
 
-            return parseFloat(payload.time || 0);
+            const savedTime = parseFloat(payload.time || 0);
+            prefetchedVideoProgress.set(path, savedTime);
+            return savedTime;
         } catch (e) {
             console.error("Failed to get video time from backend", e);
             return 0;
         }
+    }
+
+    function prefetchSavedVideoTime(path) {
+        if (!path) return;
+        if (prefetchedVideoProgress.has(path)) return;
+        void getSavedVideoTime(path);
     }
 
     function restoreSavedVideoTimeAsync(pathForRequest) {
@@ -583,7 +597,9 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
 
-        void getSavedVideoTime(pathForRequest).then((savedTime) => {
+        const progressRequest = currentVideoProgressRequest || getSavedVideoTime(pathForRequest);
+
+        void progressRequest.then((savedTime) => {
             if (!player || currentVideoPath !== pathForRequest) {
                 return;
             }
@@ -601,6 +617,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 ? Math.max(0, Math.min(duration, savedTime))
                 : Math.max(0, savedTime);
             player.currentTime = boundedTime;
+            prefetchedVideoProgress.set(pathForRequest, boundedTime);
         });
     }
 
@@ -851,6 +868,7 @@ document.addEventListener('DOMContentLoaded', function() {
             player.pause();
             isVideoReadyForSave = false;
             currentVideoPath = null;
+            currentVideoProgressRequest = null;
         }
     });
     
@@ -861,9 +879,12 @@ document.addEventListener('DOMContentLoaded', function() {
         
         currentVideoPath = playBtn.dataset.videoPath; // Store current video path
         const videoName = playBtn.dataset.videoName;
-        
+
         if (!currentVideoPath) return;
-        
+
+        prefetchSavedVideoTime(currentVideoPath);
+        currentVideoProgressRequest = getSavedVideoTime(currentVideoPath);
+
         initPlyr();
         
         isVideoReadyForSave = false;


### PR DESCRIPTION
### Motivation
- Implement the requested second variant: run the app in Docker and execute shell commands over a single persistent SSH connection using an SSH key generated and managed from the host without overwriting existing host keys. 
- Reduce video player restore latency by fetching and caching saved progress earlier and reusing in-flight progress requests to avoid duplicate network roundtrips.

### Description
- Add Docker runtime and tooling: `docker-compose.yml`, `docker/php/Dockerfile`, `docker/php/init-ssh-and-run.sh`, and `docker/php/run-over-ssh.sh` that create an SSH config, start a master SSH connection (`ControlMaster`/`ControlPersist`) and provide a wrapper to run remote commands over the shared control socket. 
- Provide `scripts/setup-docker-ssh-key.sh` to generate an Ed25519 key, write `.env.ssh` with `SSH_PRIVATE_KEY_B64` and remote host info, and append the public key to the remote `~/.ssh/authorized_keys` only if it is not already present (does not overwrite host keys). 
- Update `app/ShellCommandExecutor.php` to optionally route all shell commands through the SSH wrapper when `SHELL_OVER_SSH=1`, falling back to local `shell_exec` when the wrapper is unavailable. 
- Update frontend video player logic in `templates/file_index.html.php` to add `prefetchedVideoProgress` caching and `currentVideoProgressRequest` reuse so progress is prefetched on play and the `loadedmetadata` handler can reuse an in-flight request and apply bounded restored time immediately. 
- Add `DOCKER_SSH_README.md` documenting setup and usage and update `.gitignore` to exclude `.env.ssh` and `.docker-ssh/`.

### Testing
- `php -l app/ShellCommandExecutor.php` (syntax check) — succeeded. 
- `bash -n scripts/setup-docker-ssh-key.sh` (shell syntax check) — succeeded. 
- `bash -n docker/php/init-ssh-and-run.sh` (shell syntax check) — succeeded. 
- `bash -n docker/php/run-over-ssh.sh` (shell syntax check) — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997258674b483309cb2f4af948a3a16)