### PR TITLE
Add YouTube Player feature (controller, routes, template, client UI)

### DIFF
--- a/app.php
+++ b/app.php
@@ -9,6 +9,7 @@ use App\Controller\FileIndexController;
 use App\Controller\SettingsController;
 use App\Controller\SystemController;
 use App\Controller\ToolsController;
+use App\Controller\YouTubePlayerController;
 
 $app = App::getInstance();
 $app->appRoot = __DIR__;
@@ -21,6 +22,7 @@ $router = new Router();
 (new ToolsController())->registerRoutes($router, $app->appRoot);
 (new FileIndexController())->registerRoutes($router, $app->appRoot);
 (new SettingsController())->registerRoutes($router, $app->appRoot);
+(new YouTubePlayerController())->registerRoutes($router, $app->appRoot);
 
 $routeDataDto = $router->parse($_SERVER);
 $handler = $routeDataDto->handler;

--- a/app/Controller/YouTubePlayerController.php
+++ b/app/Controller/YouTubePlayerController.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace App\Controller;
+
+use App\Router;
+
+class YouTubePlayerController
+{
+    private static function jsonResponse(array $payload, int $statusCode = 200): void
+    {
+        http_response_code($statusCode);
+        header('Content-Type: application/json; charset=utf-8');
+        echo json_encode($payload);
+        exit;
+    }
+
+    private static function getStorageBaseDir(): string
+    {
+        $candidates = [];
+
+        $customBase = trim((string)getenv('UPLOAD_BASE_DIR'));
+        if ($customBase !== '') {
+            $candidates[] = rtrim($customBase, '/') . '/rpi-mainpage-upload';
+        }
+
+        $tmp = rtrim((string)sys_get_temp_dir(), '/');
+        if ($tmp !== '') {
+            $candidates[] = $tmp . '/rpi-mainpage-upload';
+        }
+
+        $candidates[] = '/dev/shm/rpi-mainpage-upload';
+
+        foreach ($candidates as $dir) {
+            if (@is_dir($dir) || @mkdir($dir, 0775, true)) {
+                if (@is_writable($dir)) {
+                    return $dir;
+                }
+            }
+        }
+
+        $cwd = getcwd();
+        $fallback = rtrim((string)$cwd, '/') . '/tmp/rpi-mainpage-upload';
+        @mkdir($fallback, 0775, true);
+        return $fallback;
+    }
+
+    private static function getVideosStoragePath(): string
+    {
+        return rtrim(self::getStorageBaseDir(), '/') . '/youtube_videos.json';
+    }
+
+    private static function getProgressStoragePath(): string
+    {
+        return rtrim(self::getStorageBaseDir(), '/') . '/youtube_video_progress.json';
+    }
+
+    private static function loadJsonMap(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $json = @file_get_contents($path);
+        if ($json === false || trim($json) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($json, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private static function saveJsonMap(string $path, array $map): void
+    {
+        $encoded = json_encode($map, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($encoded === false) {
+            throw new \RuntimeException('Failed to encode JSON payload');
+        }
+
+        $ok = @file_put_contents($path, $encoded, LOCK_EX);
+        if ($ok === false) {
+            throw new \RuntimeException('Failed to write JSON payload');
+        }
+    }
+
+    private static function normalizeVideoId(string $videoId): string
+    {
+        $videoId = trim($videoId);
+        if (!preg_match('/^[a-zA-Z0-9_-]{11}$/', $videoId)) {
+            throw new \InvalidArgumentException('Invalid YouTube video id');
+        }
+        return $videoId;
+    }
+
+    private static function readPayload(): array
+    {
+        $payload = $_POST;
+        if (!empty($payload)) {
+            return $payload;
+        }
+
+        $raw = file_get_contents('php://input');
+        $decoded = json_decode((string)$raw, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public function registerRoutes(Router $router, string $appRoot): void
+    {
+        $router->addRoute('GET', '/youtube-player', [$this, 'index'], $appRoot . '/templates/youtube_player.html.php');
+        $router->addRoute('GET', '/youtube-player/videos', [$this, 'listVideos']);
+        $router->addRoute('POST', '/youtube-player/videos', [$this, 'addVideo']);
+        $router->addRoute('DELETE', '/youtube-player/videos', [$this, 'deleteVideo']);
+        $router->addRoute('GET', '/youtube-player/progress', [$this, 'getProgress']);
+        $router->addRoute('POST', '/youtube-player/progress', [$this, 'saveProgress']);
+    }
+
+    public function index(): array
+    {
+        return [];
+    }
+
+    public function listVideos(): string
+    {
+        $videosMap = self::loadJsonMap(self::getVideosStoragePath());
+        $progressMap = self::loadJsonMap(self::getProgressStoragePath());
+        $items = [];
+
+        foreach ($videosMap as $videoId => $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            try {
+                $normalizedId = self::normalizeVideoId((string)($item['id'] ?? $videoId));
+            } catch (\InvalidArgumentException) {
+                continue;
+            }
+
+            $rawProgress = $progressMap[$normalizedId] ?? [];
+            $time = max(0, (float)($rawProgress['time'] ?? 0));
+            $duration = max(0, (float)($rawProgress['duration'] ?? 0));
+            $percent = (int)($rawProgress['percent'] ?? 0);
+            if ($percent <= 0 && $duration > 0) {
+                $percent = (int)round(($time / $duration) * 100);
+            }
+
+            $items[] = [
+                'id' => $normalizedId,
+                'url' => (string)($item['url'] ?? ''),
+                'title' => (string)($item['title'] ?? ''),
+                'time' => $time,
+                'duration' => $duration,
+                'percent' => min(100, max(0, $percent)),
+            ];
+        }
+
+        self::jsonResponse(['ok' => true, 'videos' => array_values($items)]);
+    }
+
+    public function addVideo(): string
+    {
+        $payload = self::readPayload();
+
+        $url = trim((string)($payload['url'] ?? ''));
+        $title = trim((string)($payload['title'] ?? ''));
+
+        try {
+            $videoId = self::normalizeVideoId((string)($payload['id'] ?? ''));
+        } catch (\InvalidArgumentException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 400);
+        }
+
+        if ($url === '') {
+            self::jsonResponse(['ok' => false, 'error' => 'URL is required'], 400);
+        }
+
+        try {
+            $videosMap = self::loadJsonMap(self::getVideosStoragePath());
+            $videosMap[$videoId] = [
+                'id' => $videoId,
+                'url' => $url,
+                'title' => $title,
+            ];
+            self::saveJsonMap(self::getVideosStoragePath(), $videosMap);
+        } catch (\RuntimeException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 500);
+        }
+
+        self::jsonResponse([
+            'ok' => true,
+            'video' => [
+                'id' => $videoId,
+                'url' => $url,
+                'title' => $title,
+            ],
+        ]);
+    }
+
+    public function deleteVideo(): string
+    {
+        $videoId = (string)($_GET['id'] ?? '');
+
+        try {
+            $videoId = self::normalizeVideoId($videoId);
+        } catch (\InvalidArgumentException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 400);
+        }
+
+        try {
+            $videosMap = self::loadJsonMap(self::getVideosStoragePath());
+            unset($videosMap[$videoId]);
+            self::saveJsonMap(self::getVideosStoragePath(), $videosMap);
+
+            $progressMap = self::loadJsonMap(self::getProgressStoragePath());
+            unset($progressMap[$videoId]);
+            self::saveJsonMap(self::getProgressStoragePath(), $progressMap);
+        } catch (\RuntimeException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 500);
+        }
+
+        self::jsonResponse(['ok' => true]);
+    }
+
+    public function getProgress(): string
+    {
+        $videoId = (string)($_GET['id'] ?? '');
+
+        try {
+            $videoId = self::normalizeVideoId($videoId);
+        } catch (\InvalidArgumentException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 400);
+        }
+
+        $progressMap = self::loadJsonMap(self::getProgressStoragePath());
+        $item = is_array($progressMap[$videoId] ?? null) ? $progressMap[$videoId] : [];
+
+        $time = max(0, (float)($item['time'] ?? 0));
+        $duration = max(0, (float)($item['duration'] ?? 0));
+        $percent = min(100, max(0, (int)($item['percent'] ?? 0)));
+
+        self::jsonResponse([
+            'ok' => true,
+            'time' => $time,
+            'duration' => $duration,
+            'percent' => $percent,
+        ]);
+    }
+
+    public function saveProgress(): string
+    {
+        $payload = self::readPayload();
+
+        try {
+            $videoId = self::normalizeVideoId((string)($payload['id'] ?? ''));
+        } catch (\InvalidArgumentException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 400);
+        }
+
+        $time = max(0, (float)($payload['time'] ?? 0));
+        $duration = max(0, (float)($payload['duration'] ?? 0));
+        $percent = 0;
+        if ($duration > 0) {
+            $percent = (int)round(($time / $duration) * 100);
+        }
+        $percent = min(100, max(0, $percent));
+
+        try {
+            $progressMap = self::loadJsonMap(self::getProgressStoragePath());
+            $progressMap[$videoId] = [
+                'time' => $time,
+                'duration' => $duration,
+                'percent' => $percent,
+            ];
+            self::saveJsonMap(self::getProgressStoragePath(), $progressMap);
+        } catch (\RuntimeException $e) {
+            self::jsonResponse(['ok' => false, 'error' => $e->getMessage()], 500);
+        }
+
+        self::jsonResponse([
+            'ok' => true,
+            'time' => $time,
+            'duration' => $duration,
+            'percent' => $percent,
+        ]);
+    }
+}

--- a/templates/top_main_menu.html.php
+++ b/templates/top_main_menu.html.php
@@ -18,5 +18,6 @@
         <a class="btn btn-primary" href="/top">top</a>
         <a class="btn btn-primary" href="/file-index">file index</a>
         <a class="btn btn-primary" href="/tools">tools</a>
+        <a class="btn btn-primary" href="/youtube-player">YouTube Player</a>
     </div>
 </div>

--- a/templates/youtube_player.html.php
+++ b/templates/youtube_player.html.php
@@ -1,0 +1,406 @@
+<div class="row mt-3">
+    <div class="col-12">
+        <h3>YouTube Player</h3>
+    </div>
+</div>
+
+<div class="row g-3">
+    <div class="col-lg-8">
+        <div id="ytPlayerPlaceholder" class="border rounded p-4 bg-light text-center text-muted" style="aspect-ratio: 16 / 9; display: flex; align-items: center; justify-content: center;">
+            Выберите видео из списка справа
+        </div>
+        <div id="ytPlayerContainer" class="d-none" style="aspect-ratio: 16 / 9;"></div>
+    </div>
+    <div class="col-lg-4">
+        <form id="addYoutubeForm" class="mb-3">
+            <label for="youtubeUrlInput" class="form-label">Добавить ссылку на YouTube</label>
+            <div class="input-group">
+                <input id="youtubeUrlInput" type="url" class="form-control" placeholder="https://www.youtube.com/watch?v=..." required>
+                <button class="btn btn-primary" type="submit">Добавить</button>
+            </div>
+            <div id="youtubeFormError" class="text-danger small mt-1 d-none"></div>
+        </form>
+
+        <div class="border rounded p-2" style="max-height: 65vh; overflow: auto;">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <strong>Список видео</strong>
+                <span id="youtubeListCount" class="text-muted small">0</span>
+            </div>
+            <div id="youtubeList" class="list-group"></div>
+            <div id="youtubeEmptyState" class="text-muted small">Список пуст</div>
+        </div>
+    </div>
+</div>
+
+<script>
+(function () {
+    const listEl = document.getElementById('youtubeList');
+    const emptyStateEl = document.getElementById('youtubeEmptyState');
+    const listCountEl = document.getElementById('youtubeListCount');
+    const formEl = document.getElementById('addYoutubeForm');
+    const urlInputEl = document.getElementById('youtubeUrlInput');
+    const formErrorEl = document.getElementById('youtubeFormError');
+    const playerContainerEl = document.getElementById('ytPlayerContainer');
+    const playerPlaceholderEl = document.getElementById('ytPlayerPlaceholder');
+
+    let items = [];
+    let currentVideoId = '';
+    let player = null;
+    let isYoutubeApiReady = false;
+    let trackInterval = null;
+
+    function showFormError(text) {
+        formErrorEl.textContent = text;
+        formErrorEl.classList.remove('d-none');
+    }
+
+    function clearFormError() {
+        formErrorEl.textContent = '';
+        formErrorEl.classList.add('d-none');
+    }
+
+    function extractYoutubeVideoId(raw) {
+        const value = String(raw || '').trim();
+        if (!value) return '';
+
+        let parsed = null;
+        try {
+            parsed = new URL(value);
+        } catch (e) {
+            return '';
+        }
+
+        const host = parsed.hostname.replace(/^www\./, '').toLowerCase();
+
+        if (host === 'youtu.be') {
+            const id = parsed.pathname.replace(/^\//, '').split('/')[0];
+            return /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : '';
+        }
+
+        if (host === 'youtube.com' || host === 'm.youtube.com') {
+            if (parsed.pathname === '/watch') {
+                const id = parsed.searchParams.get('v') || '';
+                return /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : '';
+            }
+
+            const pathParts = parsed.pathname.split('/').filter(Boolean);
+            if (pathParts.length >= 2 && ['shorts', 'embed', 'live'].includes(pathParts[0])) {
+                const id = pathParts[1] || '';
+                return /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : '';
+            }
+        }
+
+        return '';
+    }
+
+    function getVideoLabel(item) {
+        return item.title && item.title.trim() ? item.title : (item.url || item.id);
+    }
+
+    function updateListMeta() {
+        listCountEl.textContent = String(items.length);
+        emptyStateEl.classList.toggle('d-none', items.length > 0);
+    }
+
+    function stopProgressTracking() {
+        if (trackInterval) {
+            clearInterval(trackInterval);
+            trackInterval = null;
+        }
+    }
+
+    async function saveProgress(videoId) {
+        if (!player || !videoId || currentVideoId !== videoId) return;
+
+        const currentTime = Number(player.getCurrentTime ? player.getCurrentTime() : 0) || 0;
+        const duration = Number(player.getDuration ? player.getDuration() : 0) || 0;
+
+        try {
+            await fetch('/youtube-player/progress', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({id: videoId, time: currentTime, duration: duration})
+            });
+
+            items = items.map((item) => {
+                if (item.id !== videoId) return item;
+                const percent = duration > 0 ? Math.max(0, Math.min(100, Math.round((currentTime / duration) * 100))) : 0;
+                return {
+                    ...item,
+                    time: currentTime,
+                    duration: duration,
+                    percent: percent,
+                };
+            });
+            renderList();
+        } catch (e) {
+            console.error('Failed to save YouTube progress', e);
+        }
+    }
+
+    function startProgressTracking(videoId) {
+        stopProgressTracking();
+        trackInterval = window.setInterval(() => {
+            void saveProgress(videoId);
+        }, 5000);
+    }
+
+    function renderList() {
+        listEl.innerHTML = '';
+
+        items.forEach((item) => {
+            const row = document.createElement('div');
+            row.className = 'list-group-item list-group-item-action';
+            if (item.id === currentVideoId) {
+                row.classList.add('active');
+            }
+
+            const top = document.createElement('div');
+            top.className = 'd-flex align-items-start justify-content-between gap-2';
+
+            const clickZone = document.createElement('button');
+            clickZone.type = 'button';
+            clickZone.className = 'btn btn-link text-start p-0 text-decoration-none flex-grow-1';
+            clickZone.innerHTML = '<div class="fw-semibold">' + getVideoLabel(item).replace(/</g, '&lt;') + '</div>'
+                + '<div class="small text-muted">' + (item.url || '').replace(/</g, '&lt;') + '</div>';
+            clickZone.addEventListener('click', () => {
+                void selectVideo(item.id);
+            });
+
+            const deleteBtn = document.createElement('button');
+            deleteBtn.type = 'button';
+            deleteBtn.className = 'btn btn-sm btn-outline-danger';
+            deleteBtn.textContent = 'Удалить';
+            deleteBtn.addEventListener('click', async () => {
+                await deleteVideo(item.id);
+            });
+
+            top.appendChild(clickZone);
+            top.appendChild(deleteBtn);
+
+            const progressWrap = document.createElement('div');
+            progressWrap.className = 'mt-2';
+            const percent = Math.max(0, Math.min(100, Number(item.percent) || 0));
+            progressWrap.innerHTML = '<div class="d-flex justify-content-between small text-muted mb-1"><span>Прогресс</span><span>' + percent + '%</span></div>'
+                + '<div class="progress" style="height: 8px;"><div class="progress-bar" role="progressbar" style="width: ' + percent + '%;"></div></div>';
+
+            row.appendChild(top);
+            row.appendChild(progressWrap);
+            listEl.appendChild(row);
+        });
+
+        updateListMeta();
+    }
+
+    async function loadVideos() {
+        const response = await fetch('/youtube-player/videos', {cache: 'no-store'});
+        if (!response.ok) {
+            throw new Error('Failed to load videos');
+        }
+        const payload = await response.json();
+        items = Array.isArray(payload.videos) ? payload.videos : [];
+        renderList();
+    }
+
+    async function deleteVideo(videoId) {
+        const response = await fetch('/youtube-player/videos?id=' + encodeURIComponent(videoId), {
+            method: 'DELETE'
+        });
+
+        if (!response.ok) {
+            return;
+        }
+
+        items = items.filter((item) => item.id !== videoId);
+        if (currentVideoId === videoId) {
+            currentVideoId = '';
+            stopProgressTracking();
+            if (player && typeof player.stopVideo === 'function') {
+                player.stopVideo();
+            }
+            playerContainerEl.classList.add('d-none');
+            playerPlaceholderEl.classList.remove('d-none');
+        }
+        renderList();
+    }
+
+    async function updateVideoTitle(videoId, title) {
+        if (!videoId || !title) return;
+
+        const item = items.find((entry) => entry.id === videoId);
+        if (!item || (item.title && item.title.trim())) {
+            return;
+        }
+
+        try {
+            await fetch('/youtube-player/videos', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({id: item.id, url: item.url, title: title})
+            });
+
+            items = items.map((entry) => entry.id === videoId ? ({...entry, title: title}) : entry);
+            renderList();
+        } catch (e) {
+            console.error('Failed to update title', e);
+        }
+    }
+
+    async function getSavedProgress(videoId) {
+        const response = await fetch('/youtube-player/progress?id=' + encodeURIComponent(videoId), {cache: 'no-store'});
+        if (!response.ok) {
+            return 0;
+        }
+        const payload = await response.json();
+        return Math.max(0, Number(payload.time) || 0);
+    }
+
+    function ensureYoutubeApi() {
+        if (window.YT && window.YT.Player) {
+            isYoutubeApiReady = true;
+            return Promise.resolve();
+        }
+
+        return new Promise((resolve) => {
+            const previousReady = window.onYouTubeIframeAPIReady;
+            window.onYouTubeIframeAPIReady = function () {
+                isYoutubeApiReady = true;
+                if (typeof previousReady === 'function') {
+                    previousReady();
+                }
+                resolve();
+            };
+
+            if (!document.querySelector('script[data-yt-api="1"]')) {
+                const script = document.createElement('script');
+                script.src = 'https://www.youtube.com/iframe_api';
+                script.async = true;
+                script.dataset.ytApi = '1';
+                document.head.appendChild(script);
+            }
+        });
+    }
+
+    async function selectVideo(videoId) {
+        const item = items.find((entry) => entry.id === videoId);
+        if (!item) {
+            return;
+        }
+
+        await ensureYoutubeApi();
+        if (!isYoutubeApiReady) {
+            return;
+        }
+
+        currentVideoId = videoId;
+        renderList();
+
+        const startSeconds = await getSavedProgress(videoId);
+
+        playerPlaceholderEl.classList.add('d-none');
+        playerContainerEl.classList.remove('d-none');
+
+        if (!player) {
+            player = new YT.Player('ytPlayerContainer', {
+                width: '100%',
+                height: '100%',
+                videoId: videoId,
+                playerVars: {
+                    autoplay: 1,
+                    start: Math.floor(startSeconds),
+                    rel: 0,
+                    modestbranding: 1
+                },
+                events: {
+                    onReady: function (event) {
+                        if (startSeconds > 0) {
+                            event.target.seekTo(startSeconds, true);
+                        }
+                        event.target.playVideo();
+                        const data = event.target.getVideoData ? event.target.getVideoData() : null;
+                        if (data && data.title) {
+                            void updateVideoTitle(videoId, data.title);
+                        }
+                    },
+                    onStateChange: function (event) {
+                        const state = event.data;
+                        if (state === YT.PlayerState.PLAYING) {
+                            startProgressTracking(videoId);
+                            const data = player.getVideoData ? player.getVideoData() : null;
+                            if (data && data.title) {
+                                void updateVideoTitle(videoId, data.title);
+                            }
+                            return;
+                        }
+
+                        if (state === YT.PlayerState.PAUSED || state === YT.PlayerState.ENDED) {
+                            stopProgressTracking();
+                            void saveProgress(videoId);
+                        }
+                    }
+                }
+            });
+        } else {
+            player.loadVideoById({
+                videoId: videoId,
+                startSeconds: Math.floor(startSeconds)
+            });
+        }
+    }
+
+    formEl.addEventListener('submit', async function (event) {
+        event.preventDefault();
+        clearFormError();
+
+        const rawUrl = urlInputEl.value.trim();
+        const videoId = extractYoutubeVideoId(rawUrl);
+
+        if (!videoId) {
+            showFormError('Введите корректную ссылку на YouTube видео.');
+            return;
+        }
+
+        if (items.some((item) => item.id === videoId)) {
+            showFormError('Это видео уже добавлено в список.');
+            return;
+        }
+
+        const response = await fetch('/youtube-player/videos', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({id: videoId, url: rawUrl})
+        });
+
+        if (!response.ok) {
+            showFormError('Не удалось добавить видео.');
+            return;
+        }
+
+        const payload = await response.json();
+        if (!payload || !payload.ok || !payload.video) {
+            showFormError('Некорректный ответ от сервера.');
+            return;
+        }
+
+        items.push({
+            id: payload.video.id,
+            url: payload.video.url,
+            title: payload.video.title || '',
+            time: 0,
+            duration: 0,
+            percent: 0,
+        });
+
+        urlInputEl.value = '';
+        renderList();
+    });
+
+    window.addEventListener('beforeunload', () => {
+        if (currentVideoId) {
+            void saveProgress(currentVideoId);
+        }
+    });
+
+    void loadVideos();
+})();
+</script>


### PR DESCRIPTION
### Motivation
- Provide an embedded YouTube player feature with a manageable playlist and resumeable playback across sessions. 
- Persist video entries and per-video playback progress so users can add/remove videos and continue where they left off.

### Description
- Register the new `YouTubePlayerController` in `app.php` and expose the routes `GET /youtube-player`, `GET|POST|DELETE /youtube-player/videos`, and `GET|POST /youtube-player/progress`.
- Add `app/Controller/YouTubePlayerController.php` which implements JSON storage helpers, `getStorageBaseDir()`, `normalizeVideoId()`, and endpoints to list/add/delete videos and get/save progress using JSON files `youtube_videos.json` and `youtube_video_progress.json`.
- Add the frontend template `templates/youtube_player.html.php` which contains the UI and client-side JavaScript to call the new API, manage the video list, load the YouTube IFrame API, track playback progress, and save progress periodically and on unload.
- Update `templates/top_main_menu.html.php` to include a link to the new YouTube Player page.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85daab30083309314d88875052168)