### PR TITLE
Refresh UI colors, background, and button spacing

### DIFF
--- a/templates/bottom_main_menu.html.php
+++ b/templates/bottom_main_menu.html.php
@@ -1,8 +1,6 @@
 <div class="row">
-    <div class="col-sm">
+    <div class="col-sm d-flex flex-wrap gap-2">
         <a class="btn btn-primary" href="/update-code">git pull</a>
-    </div>
-    <div class="col-sm">
         <a class="btn btn-secondary" href="/settings">Settings</a>
     </div>
 </div>

--- a/templates/top_main_menu.html.php
+++ b/templates/top_main_menu.html.php
@@ -1,5 +1,5 @@
-<div class="row">
-    <div class="col-sm">
+<div class="row mb-2">
+    <div class="col-sm d-flex flex-wrap gap-2">
         <?php
             if (isset($topMainMenu) && is_array($topMainMenu)) {
                 foreach ($topMainMenu as $menuItem) {
@@ -12,8 +12,8 @@
         ?>
     </div>
 </div>
-<div class="row">
-    <div class="col-sm">
+<div class="row mb-2">
+    <div class="col-sm d-flex flex-wrap gap-2">
         <a class="btn btn-primary" href="/">index</a>
         <a class="btn btn-primary" href="/top">top</a>
         <a class="btn btn-primary" href="/file-index">file index</a>

--- a/web/css/custom.css
+++ b/web/css/custom.css
@@ -1,3 +1,33 @@
+.page-shell {
+    background-color: #f2f4f6;
+    min-height: 100vh;
+}
+
+:root {
+    --bs-primary: #30b6c2;
+    --bs-primary-rgb: 48, 182, 194;
+}
+
+.btn-primary {
+    --bs-btn-bg: #30b6c2;
+    --bs-btn-border-color: #30b6c2;
+    --bs-btn-hover-bg: #289ca6;
+    --bs-btn-hover-border-color: #289ca6;
+    --bs-btn-active-bg: #22858e;
+    --bs-btn-active-border-color: #22858e;
+    --bs-btn-disabled-bg: #30b6c2;
+    --bs-btn-disabled-border-color: #30b6c2;
+}
+
+.btn-outline-primary {
+    --bs-btn-color: #30b6c2;
+    --bs-btn-border-color: #30b6c2;
+    --bs-btn-hover-bg: #30b6c2;
+    --bs-btn-hover-border-color: #30b6c2;
+    --bs-btn-active-bg: #289ca6;
+    --bs-btn-active-border-color: #289ca6;
+}
+
 .video-modal .modal-dialog {
     max-width: 90vw;
 }
@@ -7,7 +37,7 @@
 }
 /* Establish stacking context for the player */
 .video-modal .plyr {
-    --plyr-color-main: #0d6efd;
+    --plyr-color-main: #30b6c2;
     position: relative !important;
     z-index: 1;
 }

--- a/web/index.html.php
+++ b/web/index.html.php
@@ -13,7 +13,7 @@
         <link rel="stylesheet" href="https://cdn.plyr.io/3.7.8/plyr.css" />
         <link rel="stylesheet" href="/web/css/custom.css">
     </head>
-    <body>
+    <body class="page-shell">
         <div class="container">
             <?php
                 /** @var string $body */


### PR DESCRIPTION
### Motivation
- Refresh the main page design by replacing the default Bootstrap blue with `#30b6c2`, switching the page background from white to a light gray, and fixing vertically-collapsing buttons so they don't "stick" when wrapped.

### Description
- Added a `.page-shell` class and applied it to the `<body>` to set the page background to `#f2f4f6` and ensure full-height shell via `min-height: 100vh` in `web/css/custom.css` and `web/index.html.php`.
- Replaced the primary color variables and button overrides to `#30b6c2` and tuned hover/active states, including `:root` variables and `.btn-primary` / `.btn-outline-primary` overrides in `web/css/custom.css`.
- Updated the Plyr player accent by changing `--plyr-color-main` to `#30b6c2` in `web/css/custom.css`.
- Prevented buttons from collapsing together by making the top and bottom menus use `d-flex flex-wrap gap-2` and added small vertical spacing with `mb-2` in `templates/top_main_menu.html.php` and `templates/bottom_main_menu.html.php`.

### Testing
- Ran PHP lint checks with `php -l web/index.html.php`, `php -l templates/top_main_menu.html.php`, and `php -l templates/bottom_main_menu.html.php`, and all returned "No syntax errors detected.".
- Attempted an automated screenshot with Playwright Chromium which failed with a native crash (`SIGSEGV`) in the environment, and an automated Playwright Firefox run successfully produced a screenshot artifact of the updated main page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86bc9dec88330ab9b1f9f683292fd)