### PR TITLE
Persist YouTube player storage on host-mounted path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - .env.ssh
     environment:
       SHELL_OVER_SSH: "1"
+      # Keep app state on host-mounted storage so data survives container rebuilds.
+      UPLOAD_BASE_DIR: /media/.rpi-mainpage-data
       APP_RUN_USER: ${APP_RUN_USER:-ubuntu}
       SSH_REMOTE_HOST: ${SSH_REMOTE_HOST:-host.docker.internal}
       SSH_REMOTE_PORT: ${SSH_REMOTE_PORT:-22}


### PR DESCRIPTION
### Motivation
- Prevent the YouTube links and progress JSON files from being lost when the app container is rebuilt by moving their storage base directory to a host-mounted path.

### Description
- Added `UPLOAD_BASE_DIR: /media/.rpi-mainpage-data` (with a comment) to the `app` service in `docker-compose.yml` so the app will store `youtube_videos.json` and `youtube_video_progress.json` on the mounted `/media` volume.

### Testing
- Ran `docker compose config` but the Docker CLI is not available in this environment; verified the change with `git diff` and `git status` and committed the update successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87285d3e483309afb632c6ddb76c2)