### PR TITLE
Prefer host-side execution for `top` and add optional SSH-forcing to shell executor

### DIFF
--- a/app/Controller/SystemController.php
+++ b/app/Controller/SystemController.php
@@ -114,8 +114,11 @@ class SystemController
 
     public function top(): array
     {
-        $command = 'top -b -n 1 2>&1 | head -20 2>&1';
-        return ['shellCommandRawContent' => ShellCommandExecutor::executeWithSplitByLines($command)];
+        $command = 'top -b -n 1 2>&1 | head -20';
+
+        // Always prefer host-side execution for /top (via SSH wrapper when available)
+        // so system metrics represent the actual host, not the PHP container.
+        return ['shellCommandRawContent' => ShellCommandExecutor::executeWithSplitByLines($command, true)];
     }
 
     public function updateCode(): array

--- a/app/ShellCommandExecutor.php
+++ b/app/ShellCommandExecutor.php
@@ -4,9 +4,9 @@ namespace App;
 
 class ShellCommandExecutor
 {
-    public static function execute(string $command): string
+    public static function execute(string $command, bool $forceSsh = false): string
     {
-        $effectiveCommand = self::buildEffectiveCommand($command);
+        $effectiveCommand = self::buildEffectiveCommand($command, $forceSsh);
         $result = shell_exec($effectiveCommand);
 
         if ($result === null) {
@@ -16,10 +16,10 @@ class ShellCommandExecutor
         return $result;
     }
 
-    public static function executeWithSplitByLines(string $command): array
+    public static function executeWithSplitByLines(string $command, bool $forceSsh = false): array
     {
         try {
-            $result = self::execute($command);
+            $result = self::execute($command, $forceSsh);
         } catch (\RuntimeException $e) {
             return [
                 $e->getMessage(),
@@ -28,9 +28,11 @@ class ShellCommandExecutor
         return explode("\n", $result);
     }
 
-    private static function buildEffectiveCommand(string $command): string
+    private static function buildEffectiveCommand(string $command, bool $forceSsh = false): string
     {
-        if (getenv('SHELL_OVER_SSH') !== '1') {
+        $shouldUseSsh = $forceSsh || getenv('SHELL_OVER_SSH') === '1';
+
+        if (!$shouldUseSsh) {
             return $command;
         }
 


### PR DESCRIPTION
### Motivation
- Ensure `/top` reports host metrics when an SSH wrapper is available by running the command on the host instead of inside the PHP container.
- Add a way for callers to force SSH execution of shell commands while preserving backward compatibility and fallback behavior.

### Description
- Modified `SystemController::top()` to call `ShellCommandExecutor::executeWithSplitByLines($command, true)` and prefer host-side execution for the `top` output.
- Added an optional `bool $forceSsh` parameter to `ShellCommandExecutor::execute()`, `executeWithSplitByLines()` and `buildEffectiveCommand()` to allow callers to request SSH-wrapped execution explicitly.
- `buildEffectiveCommand()` now computes `$shouldUseSsh = $forceSsh || getenv('SHELL_OVER_SSH') === '1'` and falls back to the local command if the SSH wrapper is not executable.
- Simplified the `top` pipeline by removing the duplicate trailing `2>&1` from the `head` invocation.

### Testing
- Ran PHP linting (`php -l`) on modified files and it succeeded.
- Executed the project's automated test suite (`vendor/bin/phpunit`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87ad2ccbc83309305beda12255753)