### PR TITLE
Add APP_RUN_GROUPS to allow file manager write access in www-data-owned media dirs

### DIFF
--- a/DOCKER_SSH_README.md
+++ b/DOCKER_SSH_README.md
@@ -16,11 +16,15 @@ What the script does:
 Optional variable in `.env.ssh`:
 - `SSH_REMOTE_APP_DIR` — absolute path to this project on remote host (default: `/apps/rpi-mainpage`)
 - `APP_RUN_USER` — PHP-FPM runtime user inside container (default: `ubuntu`, uid `1000`)
+- `APP_RUN_GROUPS` — extra groups added to `APP_RUN_USER` on container startup (default: `www-data`)
 
 This path is used by the **pull** button and composer install commands.
 
 `APP_RUN_USER=ubuntu` helps writes to bind-mounted host directories (uploads, URL downloads, NFO save)
 when those paths are owned by host user with uid `1000`.
+
+If media folders are owned by `www-data:www-data` with mode like `drwxrwxr-x`, keep
+`APP_RUN_GROUPS=www-data` so file manager can create/delete entries there.
 
 ## 2) Start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # Keep app state on host-mounted storage so data survives container rebuilds.
       UPLOAD_BASE_DIR: /media/.rpi-mainpage-data
       APP_RUN_USER: ${APP_RUN_USER:-ubuntu}
+      APP_RUN_GROUPS: ${APP_RUN_GROUPS:-www-data}
       SSH_REMOTE_HOST: ${SSH_REMOTE_HOST:-host.docker.internal}
       SSH_REMOTE_PORT: ${SSH_REMOTE_PORT:-22}
       SSH_REMOTE_USER: ${SSH_REMOTE_USER:-ubuntu}

--- a/docker/php/init-ssh-and-run.sh
+++ b/docker/php/init-ssh-and-run.sh
@@ -41,6 +41,14 @@ chmod 600 "$CONFIG_PATH"
 # Ensure PHP-FPM worker user can access SSH key/config.
 # By default php-fpm runs as www-data inside php:8.2-fpm.
 APP_RUN_USER="${APP_RUN_USER:-www-data}"
+APP_RUN_GROUPS="${APP_RUN_GROUPS:-www-data}"
+
+if id "$APP_RUN_USER" >/dev/null 2>&1 && [ -n "$APP_RUN_GROUPS" ]; then
+  # Allow the runtime user to write into bind-mounted directories owned by
+  # service accounts (e.g. www-data:www-data with mode 775).
+  usermod -a -G "$APP_RUN_GROUPS" "$APP_RUN_USER" || true
+fi
+
 if id "$APP_RUN_USER" >/dev/null 2>&1; then
   chown -R "$APP_RUN_USER:$APP_RUN_USER" "$SSH_DIR"
 


### PR DESCRIPTION
### Motivation
- File manager could not create or delete files in host media directories owned by `www-data:www-data` with mode like `drwxrwxr-x` because the PHP-FPM runtime user was not in the `www-data` group. 
- Provide a runtime-configurable way to add supplementary groups to the PHP-FPM user so bind-mounted media dirs remain writable by the app.

### Description
- Add `APP_RUN_GROUPS` environment variable support and default it to `www-data` in `docker-compose.yml`. 
- Update `docker/php/init-ssh-and-run.sh` to read `APP_RUN_GROUPS` and run `usermod -a -G "$APP_RUN_GROUPS" "$APP_RUN_USER"` at container startup (safe `|| true` fallback). 
- Update `DOCKER_SSH_README.md` to document the new `APP_RUN_GROUPS` variable and explain the `www-data:www-data` ownership scenario.

### Testing
- Ran `bash -n docker/php/init-ssh-and-run.sh` to verify shell script syntax, which succeeded. 
- Attempted `docker compose config` to validate compose wiring, but the `docker` CLI is not available in this environment (`bash: command not found: docker`). 
- Verified repository diffs and that the three files were updated and committed in the workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac4f65f788330bd15d1cd73b9f8cb)