### PR TITLE
Auto-load .env.ssh, add APP_RUN_GROUPS and runtime group handling for SSH init

### DIFF
--- a/DOCKER_SSH_README.md
+++ b/DOCKER_SSH_README.md
@@ -16,11 +16,18 @@ What the script does:
 Optional variable in `.env.ssh`:
 - `SSH_REMOTE_APP_DIR` — absolute path to this project on remote host (default: `/apps/rpi-mainpage`)
 - `APP_RUN_USER` — PHP-FPM runtime user inside container (default: `ubuntu`, uid `1000`)
+- `APP_RUN_GROUPS` — extra groups added to `APP_RUN_USER` on container startup (default: `www-data`)
 
 This path is used by the **pull** button and composer install commands.
 
 `APP_RUN_USER=ubuntu` helps writes to bind-mounted host directories (uploads, URL downloads, NFO save)
 when those paths are owned by host user with uid `1000`.
+
+When running `docker/php/init-ssh-and-run.sh` manually, it now auto-loads SSH variables
+from `/app/.env.ssh` (inside container) or `./.env.ssh` (current directory).
+
+If media folders are owned by `www-data:www-data` with mode like `drwxrwxr-x`, keep
+`APP_RUN_GROUPS=www-data` so file manager can create/delete entries there.
 
 ## 2) Start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # Keep app state on host-mounted storage so data survives container rebuilds.
       UPLOAD_BASE_DIR: /media/.rpi-mainpage-data
       APP_RUN_USER: ${APP_RUN_USER:-ubuntu}
+      APP_RUN_GROUPS: ${APP_RUN_GROUPS:-www-data}
       SSH_REMOTE_HOST: ${SSH_REMOTE_HOST:-host.docker.internal}
       SSH_REMOTE_PORT: ${SSH_REMOTE_PORT:-22}
       SSH_REMOTE_USER: ${SSH_REMOTE_USER:-ubuntu}

--- a/docker/php/init-ssh-and-run.sh
+++ b/docker/php/init-ssh-and-run.sh
@@ -8,13 +8,30 @@ CONFIG_PATH="$SSH_DIR/config"
 mkdir -p "$SSH_DIR"
 chmod 700 "$SSH_DIR"
 
+
+ENV_FILE="${SSH_ENV_FILE:-}"
+if [ -z "$ENV_FILE" ]; then
+  if [ -f "/app/.env.ssh" ]; then
+    ENV_FILE="/app/.env.ssh"
+  elif [ -f ".env.ssh" ]; then
+    ENV_FILE=".env.ssh"
+  fi
+fi
+
+if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
 if [ -n "${SSH_PRIVATE_KEY_B64:-}" ]; then
   printf '%s' "$SSH_PRIVATE_KEY_B64" | base64 -d > "$KEY_PATH"
   chmod 600 "$KEY_PATH"
 fi
 
 if [ ! -s "$KEY_PATH" ]; then
-  echo "SSH key is missing. Run scripts/setup-docker-ssh-key.sh first." >&2
+  echo "SSH key is missing. Set SSH_PRIVATE_KEY_B64 or provide .env.ssh (auto-loaded from /app/.env.ssh or ./.env.ssh)." >&2
   exit 1
 fi
 
@@ -41,6 +58,14 @@ chmod 600 "$CONFIG_PATH"
 # Ensure PHP-FPM worker user can access SSH key/config.
 # By default php-fpm runs as www-data inside php:8.2-fpm.
 APP_RUN_USER="${APP_RUN_USER:-www-data}"
+APP_RUN_GROUPS="${APP_RUN_GROUPS:-www-data}"
+
+if id "$APP_RUN_USER" >/dev/null 2>&1 && [ -n "$APP_RUN_GROUPS" ]; then
+  # Allow the runtime user to write into bind-mounted directories owned by
+  # service accounts (e.g. www-data:www-data with mode 775).
+  usermod -a -G "$APP_RUN_GROUPS" "$APP_RUN_USER" || true
+fi
+
 if id "$APP_RUN_USER" >/dev/null 2>&1; then
   chown -R "$APP_RUN_USER:$APP_RUN_USER" "$SSH_DIR"
 
@@ -49,6 +74,11 @@ if id "$APP_RUN_USER" >/dev/null 2>&1; then
 else
   # Fallback if the runtime user does not exist.
   ssh -F "$CONFIG_PATH" -MNf remote-target || true
+fi
+
+if [ "$#" -eq 0 ]; then
+  echo "SSH initialization completed (no command provided)."
+  exit 0
 fi
 
 exec "$@"


### PR DESCRIPTION
### Motivation

- Allow the SSH init script to pick up SSH-related environment from a project `.env.ssh` inside the container or the current directory so containers started manually still work. 
- Support adding extra supplemental groups for the runtime user so bind-mounted media folders owned by service accounts remain writable by the app runtime. 
- Improve UX by clarifying missing-key diagnostics and exiting cleanly when no command is provided to the init script.

### Description

- Updated `docker/php/init-ssh-and-run.sh` to auto-load an env file from `/app/.env.ssh` or `./.env.ssh` unless overridden by `SSH_ENV_FILE`, to decode `SSH_PRIVATE_KEY_B64`, and to fail with a more informative message if the key is missing. 
- Added `APP_RUN_GROUPS` handling in the init script to append extra groups to the runtime user via `usermod -a -G`, and kept the existing logic to `chown` the SSH dir and warm up the control master `ssh` connection as the runtime user. 
- Made the init script exit with a friendly message if no command is supplied after initialization. 
- Added `APP_RUN_GROUPS` to `docker-compose.yml` environment with a default of `www-data`. 
- Documented `APP_RUN_GROUPS`, auto-loading behavior for `.env.ssh`, and guidance about keeping `APP_RUN_GROUPS=www-data` in `DOCKER_SSH_README.md`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac4f65f788330bd15d1cd73b9f8cb)