### PR TITLE
Fix Docker SSH setup default host

### DIFF
--- a/DOCKER_SSH_README.md
+++ b/DOCKER_SSH_README.md
@@ -14,6 +14,7 @@ What the script does:
 - appends the public key to remote `~/.ssh/authorized_keys` only if it is not already present (does not overwrite existing keys)
 
 Optional variable in `.env.ssh`:
+- `SSH_REMOTE_HOST` — SSH endpoint reachable from the `app` container (default: `host.docker.internal`)
 - `SSH_REMOTE_APP_DIR` — absolute path to this project on remote host (default: `/apps/rpi-mainpage`)
 - `APP_RUN_USER` — PHP-FPM runtime user inside container (default: `ubuntu`, uid `1000`)
 - `APP_RUN_GROUPS` — extra groups added to `APP_RUN_USER` on container startup (default: `www-data`)

--- a/scripts/setup-docker-ssh-key.sh
+++ b/scripts/setup-docker-ssh-key.sh
@@ -17,15 +17,15 @@ fi
 chmod 600 "${KEY_PATH}"
 chmod 644 "${PUB_PATH}"
 
-DEFAULT_HOST="${SSH_REMOTE_HOST:-}"
+DEFAULT_HOST="${SSH_REMOTE_HOST:-host.docker.internal}"
 DEFAULT_PORT="${SSH_REMOTE_PORT:-22}"
 DEFAULT_USER="${SSH_REMOTE_USER:-ubuntu}"
 
-read -r -p "Remote host [${DEFAULT_HOST:-127.0.0.1}]: " INPUT_HOST || true
+read -r -p "Remote host [${DEFAULT_HOST}]: " INPUT_HOST || true
 read -r -p "Remote port [${DEFAULT_PORT}]: " INPUT_PORT || true
 read -r -p "Remote user [${DEFAULT_USER}]: " INPUT_USER || true
 
-REMOTE_HOST="${INPUT_HOST:-${DEFAULT_HOST:-127.0.0.1}}"
+REMOTE_HOST="${INPUT_HOST:-${DEFAULT_HOST}}"
 REMOTE_PORT="${INPUT_PORT:-${DEFAULT_PORT}}"
 REMOTE_USER="${INPUT_USER:-${DEFAULT_USER}}"
 


### PR DESCRIPTION
### Motivation
- SSH features broke after generating `.env.ssh` because `SSH_REMOTE_HOST` could be set to `127.0.0.1`, which from inside the `app` container points to the container itself instead of the host/remote, so the default should match Docker's reachable host.

### Description
- Set the default host to `host.docker.internal` and adjusted the interactive prompt/default resolution in `scripts/setup-docker-ssh-key.sh`, and documented the `SSH_REMOTE_HOST` default in `DOCKER_SSH_README.md`.

### Testing
- Verified script syntax with `bash -n scripts/setup-docker-ssh-key.sh` which succeeded; attempted `docker compose config` but the `docker` CLI was not available in the environment so full compose validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad83691608330b5c56b0ac618e249)