### PR TITLE
Docker SSH: default host, provisioning fallback, and README clarification

### DIFF
--- a/DOCKER_SSH_README.md
+++ b/DOCKER_SSH_README.md
@@ -14,6 +14,8 @@ What the script does:
 - appends the public key to remote `~/.ssh/authorized_keys` only if it is not already present (does not overwrite existing keys)
 
 Optional variable in `.env.ssh`:
+- `SSH_REMOTE_HOST` — SSH endpoint reachable from the `app` container (default: `host.docker.internal`)
+  - note: `setup-docker-ssh-key.sh` should be run on host; for key provisioning it auto-falls back to `127.0.0.1` if `host.docker.internal` is not resolvable on host
 - `SSH_REMOTE_APP_DIR` — absolute path to this project on remote host (default: `/apps/rpi-mainpage`)
 - `APP_RUN_USER` — PHP-FPM runtime user inside container (default: `ubuntu`, uid `1000`)
 - `APP_RUN_GROUPS` — extra groups added to `APP_RUN_USER` on container startup (default: `www-data`)

--- a/scripts/setup-docker-ssh-key.sh
+++ b/scripts/setup-docker-ssh-key.sh
@@ -17,15 +17,15 @@ fi
 chmod 600 "${KEY_PATH}"
 chmod 644 "${PUB_PATH}"
 
-DEFAULT_HOST="${SSH_REMOTE_HOST:-}"
+DEFAULT_HOST="${SSH_REMOTE_HOST:-host.docker.internal}"
 DEFAULT_PORT="${SSH_REMOTE_PORT:-22}"
 DEFAULT_USER="${SSH_REMOTE_USER:-ubuntu}"
 
-read -r -p "Remote host [${DEFAULT_HOST:-127.0.0.1}]: " INPUT_HOST || true
+read -r -p "Remote host for container [${DEFAULT_HOST}]: " INPUT_HOST || true
 read -r -p "Remote port [${DEFAULT_PORT}]: " INPUT_PORT || true
 read -r -p "Remote user [${DEFAULT_USER}]: " INPUT_USER || true
 
-REMOTE_HOST="${INPUT_HOST:-${DEFAULT_HOST:-127.0.0.1}}"
+REMOTE_HOST="${INPUT_HOST:-${DEFAULT_HOST}}"
 REMOTE_PORT="${INPUT_PORT:-${DEFAULT_PORT}}"
 REMOTE_USER="${INPUT_USER:-${DEFAULT_USER}}"
 
@@ -35,16 +35,23 @@ if [ -z "${REMOTE_HOST}" ] || [ -z "${REMOTE_USER}" ]; then
 fi
 
 KEY_B64="$(base64 -w0 "${KEY_PATH}")"
-cat > "${ENV_FILE}" <<EOF
+cat > "${ENV_FILE}" <<EOF_ENV
 SSH_REMOTE_HOST=${REMOTE_HOST}
 SSH_REMOTE_PORT=${REMOTE_PORT}
 SSH_REMOTE_USER=${REMOTE_USER}
 SSH_PRIVATE_KEY_B64=${KEY_B64}
-EOF
+EOF_ENV
+
+# The value in .env.ssh must be reachable from Docker container.
+# For one-time key provisioning from host machine, use a host-reachable fallback.
+PROVISION_HOST="${SSH_PROVISION_HOST:-${REMOTE_HOST}}"
+if [ "${REMOTE_HOST}" = "host.docker.internal" ] && ! getent hosts "${REMOTE_HOST}" >/dev/null 2>&1; then
+  PROVISION_HOST="127.0.0.1"
+fi
 
 PUB_KEY="$(cat "${PUB_PATH}")"
 SSH_OPTS=( -p "${REMOTE_PORT}" -o StrictHostKeyChecking=accept-new )
 
-ssh "${SSH_OPTS[@]}" "${REMOTE_USER}@${REMOTE_HOST}" "mkdir -p ~/.ssh && chmod 700 ~/.ssh && touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && grep -qxF '${PUB_KEY}' ~/.ssh/authorized_keys || echo '${PUB_KEY}' >> ~/.ssh/authorized_keys"
+ssh "${SSH_OPTS[@]}" "${REMOTE_USER}@${PROVISION_HOST}" "mkdir -p ~/.ssh && chmod 700 ~/.ssh && touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && grep -qxF '${PUB_KEY}' ~/.ssh/authorized_keys || echo '${PUB_KEY}' >> ~/.ssh/authorized_keys"
 
-echo "Prepared ${ENV_FILE} and ensured public key is present on ${REMOTE_USER}@${REMOTE_HOST}"
+echo "Prepared ${ENV_FILE} (SSH_REMOTE_HOST=${REMOTE_HOST}) and ensured public key is present on ${REMOTE_USER}@${PROVISION_HOST}"


### PR DESCRIPTION
### Motivation
- Clarify README and make the SSH setup script safer when the container cannot resolve `host.docker.internal`.
- Ensure key provisioning from the host works reliably by allowing a host-reachable fallback for the one-time SSH public-key install.

### Description
- Updated `DOCKER_SSH_README.md` to document the `SSH_REMOTE_HOST` default and note that `setup-docker-ssh-key.sh` falls back to `127.0.0.1` when `host.docker.internal` is not resolvable.
- Modified `scripts/setup-docker-ssh-key.sh` to set `DEFAULT_HOST` to `host.docker.internal`, change the prompt text, and write the env file using `EOF_ENV`.
- Added `PROVISION_HOST` logic with optional `SSH_PROVISION_HOST` override and a fallback to `127.0.0.1` when `host.docker.internal` is not resolvable, and use `PROVISION_HOST` for the SSH command that appends the public key.
- Updated the final informational echo to report the `SSH_REMOTE_HOST` and the actual host used for provisioning.

### Testing
- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad83691608330b5c56b0ac618e249)